### PR TITLE
Fix guzzle tests

### DIFF
--- a/tests/integration/guzzle5/tests/Guzzle5Test.php
+++ b/tests/integration/guzzle5/tests/Guzzle5Test.php
@@ -44,6 +44,9 @@ class Guzzle5Test extends TestCase
         }
     }
 
+    /**
+     * @runInSeparateProcess
+     */
     public function testGuzzleRequest()
     {
         $server = HttpTestServer::create(
@@ -77,6 +80,9 @@ class Guzzle5Test extends TestCase
         $this->assertEquals($server->getUrl(), $curlSpan->attributes()['uri']);
     }
 
+    /**
+     * @runInSeparateProcess
+     */
     public function testPersistsTraceContext()
     {
         $server = HttpTestServer::create(

--- a/tests/integration/guzzle6/tests/Guzzle6Test.php
+++ b/tests/integration/guzzle6/tests/Guzzle6Test.php
@@ -43,6 +43,9 @@ class Guzzle6Test extends TestCase
         $this->client = new Client(['handler' => $stack]);
     }
 
+    /**
+     * @runInSeparateProcess
+     */
     public function testGuzzleRequest()
     {
         $server = HttpTestServer::create(
@@ -77,6 +80,9 @@ class Guzzle6Test extends TestCase
         $this->assertEquals($server->getUrl(), $curlSpan->attributes()['uri']);
     }
 
+    /**
+     * @runInSeparateProcess
+     */
     public function testPersistsTraceContext()
     {
         $server = HttpTestServer::create(


### PR DESCRIPTION
This was not working properly as the Tracer was a static variable and persisted across runs