### PR TITLE
Remove stacktrace generation by default

### DIFF
--- a/src/Trace/Span.php
+++ b/src/Trace/Span.php
@@ -221,8 +221,6 @@ class Span
 
         if (array_key_exists('stackTrace', $options)) {
             $this->stackTrace = $this->filterStackTrace($options['stackTrace']);
-        } else {
-            $this->stackTrace = $this->filterStackTrace(debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS));
         }
 
         if (array_key_exists('name', $options)) {
@@ -408,7 +406,8 @@ class Span
     private function generateSpanName(): string
     {
         // Try to find the first stacktrace class entry that doesn't start with OpenCensus\Trace
-        foreach ($this->stackTrace as $st) {
+        $stackTrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
+        foreach ($stackTrace as $st) {
             $st += ['line' => null];
             if (!array_key_exists('class', $st)) {
                 return implode('/', array_filter(['app', basename($st['file']), $st['function'], $st['line']]));

--- a/tests/unit/Trace/SpanTest.php
+++ b/tests/unit/Trace/SpanTest.php
@@ -96,18 +96,6 @@ class SpanTest extends TestCase
         $this->assertInstanceOf(\DateTimeInterface::class, $span->spanData()->endTime());
     }
 
-    public function testGeneratesBacktrace()
-    {
-        $span = new Span();
-
-        $stackTrace = $span->spanData()->stackTrace();
-        $this->assertInternalType('array', $stackTrace);
-        $this->assertNotEmpty($stackTrace);
-        $stackframe = $stackTrace[0];
-        $this->assertEquals('testGeneratesBacktrace', $stackframe['function']);
-        $this->assertEquals(self::class, $stackframe['class']);
-    }
-
     public function testOverrideBacktrace()
     {
         $stackTrace = [

--- a/tests/unit/Trace/Tracer/AbstractTracerTest.php
+++ b/tests/unit/Trace/Tracer/AbstractTracerTest.php
@@ -90,16 +90,6 @@ abstract class AbstractTracerTest extends TestCase
         $this->assertEquals('bar', $attributes['foo']);
     }
 
-    public function testPersistsBacktrace()
-    {
-        $tracer = $this->makeTracer();
-        $tracer->inSpan(['name' => 'test'], function () {});
-        $spanData = $tracer->spans()[0];
-        $stackframe = $spanData->stackTrace()[0];
-        $this->assertEquals('testPersistsBacktrace', $stackframe['function']);
-        $this->assertEquals(self::class, $stackframe['class']);
-    }
-
     public function testWithSpan()
     {
         $span = new Span(['name' => 'foo']);
@@ -254,7 +244,7 @@ abstract class AbstractTracerTest extends TestCase
         $this->assertNotEquals(0, $spanData->startTime()->getTimestamp());
     }
 
-    public function testStackTraceShouldBeSet()
+    public function testStackTraceShouldNotBeSet()
     {
         $tracer = $this->makeTracer();
         $tracer->inSpan(['name' => 'foo'], function () {
@@ -266,7 +256,7 @@ abstract class AbstractTracerTest extends TestCase
         $spanData = $spans[0];
 
         $this->assertInternalType('array', $spanData->stackTrace());
-        $this->assertNotEmpty($spanData->stackTrace());
+        $this->assertEmpty($spanData->stackTrace());
     }
 
     public function testAttributesShouldBeSet()


### PR DESCRIPTION
This wastes CPU and we don't push it to the exporter.