### PR TITLE
Fix PHP 7.4 tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,6 +97,11 @@ jobs:
     docker:
       - image: circleci/php:7.3-node
 
+  php74:
+    <<: *unit-config
+    docker:
+      - image: circleci/php:7.4-node
+
   integration:
     docker:
       - image: circleci/php:7.2-node
@@ -197,4 +202,5 @@ workflows:
       - php71
       - php72
       - php73
+      - php74
       - integration

--- a/ext/tests/name_uncastable_object_74.phpt
+++ b/ext/tests/name_uncastable_object_74.phpt
@@ -2,7 +2,7 @@
 OpenCensus Trace: Providing integer as name
 --SKIPIF--
 <?php
-	if (version_compare(PHP_VERSION, '7.4.0') >= 0) echo 'skip';
+	if (version_compare(PHP_VERSION, '7.4.0') < 0) echo 'skip';
 ?>
 --FILE--
 <?php
@@ -23,4 +23,8 @@ var_dump($span->name());
 
 ?>
 --EXPECTF--
-%s fatal error: Object of class UncastableObject could not be converted to string in %s/name_uncastable_object.php on line %d
+Fatal error: %s: Object of class UncastableObject could not be converted to string in %s/name_uncastable_object_74.php:%d
+Stack trace:
+#0 %s/name_uncastable_object_74.php(%d): opencensus_trace_begin('foo', Array)
+#1 {main}
+  thrown in %s/name_uncastable_object_74.php on line %d


### PR DESCRIPTION
## Description

The tests for php 7.4 extension are broken due to the different in out of `name_uncastable_object.phpt` in new php.

Since there is no change in the extension's code case, I think we can use `--SKIPIF--` to distinguish the tests for php 7.4 and older versions