### PR TITLE
Fix unit tests in php 7.4

### DIFF
--- a/src/Trace/Propagator/CloudTraceFormatter.php
+++ b/src/Trace/Propagator/CloudTraceFormatter.php
@@ -89,7 +89,7 @@ class CloudTraceFormatter implements FormatterInterface
         $result = '';
 
         for ($i = 0; $i < $length; $i++) {
-            $number[$i] = strpos($chars, $numstring{$i});
+            $number[$i] = strpos($chars, $numstring[$i]);
         }
 
         do {
@@ -105,7 +105,7 @@ class CloudTraceFormatter implements FormatterInterface
                 }
             }
             $length = $newlen;
-            $result = $newstring{$divide} . $result;
+            $result = $newstring[$divide] . $result;
         } while ($newlen != 0);
 
         return $result;


### PR DESCRIPTION
We have bunch of [failing unit tests](https://circleci.com/gh/nenad/opencensus-php/842?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link) in `master` due to #38 

This PR is for fixing that

I ran the tests on local with php 7.4, it's good

```
PHPUnit 5.7.27 by Sebastian Bergmann and contributors.

........................S......................................  63 / 245 ( 25%)
............................................................... 126 / 245 ( 51%)
............................................................... 189 / 245 ( 77%)
........................................................        245 / 245 (100%)

Time: 6.79 seconds, Memory: 14.00MB

OK, but incomplete, skipped, or risky tests!
Tests: 245, Assertions: 615, Skipped: 1.

Generating code coverage report in Clover XML format ... done
```